### PR TITLE
Handling DNS errors

### DIFF
--- a/RedditImageScraper.py
+++ b/RedditImageScraper.py
@@ -133,9 +133,9 @@ def download_file(url, date_created, filename, subreddit):
 
     with open(path, 'wb') as f:
         start = datetime.now()
-        response = requests.get(url)
-
-        if not response.status_code == 200:
+        try:
+            response = requests.get(url, timeout=3)
+        except requests.exceptions.ConnectionError as e:
             return -1
 
         f.write(response.content)


### PR DESCRIPTION
When url returns DNS_PROBE_FINISHED_NXDOMAIN previous error handling doesn't work.
I left "as e:" on line 138 for further debugging process